### PR TITLE
Fix null handling in ServiceFactory.provideConfig

### DIFF
--- a/src/main/java/art/galushko/gitlab/mrconflict/di/ServiceFactory.java
+++ b/src/main/java/art/galushko/gitlab/mrconflict/di/ServiceFactory.java
@@ -56,6 +56,9 @@ public class ServiceFactory {
      * @throws IllegalArgumentException if the provided configuration is null
      */
     public static synchronized void provideConfig(AppConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("AppConfig must not be null");
+        }
         instance = new ServiceFactory(config);
     }
 


### PR DESCRIPTION
## Summary
- prevent `ServiceFactory` from being initialized with a null config
- throw `IllegalArgumentException` when `AppConfig` is null

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ac78cc8f08329afb71b268fc10b2f